### PR TITLE
Update github_url to point to correct repository

### DIFF
--- a/src/github.tsx
+++ b/src/github.tsx
@@ -1,2 +1,2 @@
 export const github_url = (page_name: string): string =>
-  `https://github.com/andrewaylett/aylett.co.uk/commits/main/src/pages${page_name}.mdx`
+  `https://github.com/andrewaylett/closedbecause.xyz/commits/main/src/pages${page_name}.mdx`


### PR DESCRIPTION
The Revision History link points to a 404 as it is pointing to [https://github.com/andrewaylett/aylett.co.uk/commits/main/src/pages/spam.mdx](https://github.com/andrewaylett/aylett.co.uk/commits/main/src/pages/spam.mdx) (notice the aylett.co.uk as the repository name). I've updated the link to point to the closedebcause.xyz repository. 

e.g. this page's Last Revised link [https://closedbecause.xyz/spam](https://closedbecause.xyz/spam) .